### PR TITLE
Show temperature with weather icon

### DIFF
--- a/Post.swift
+++ b/Post.swift
@@ -72,6 +72,13 @@ struct Post: Identifiable, Codable {
         }
     }
 
+    /// Temperature in Fahrenheit as a rounded string with degree symbol
+    var tempString: String? {
+        guard let c = temp else { return nil }
+        let f = c * 9 / 5 + 32
+        return String(format: "%.0f\u{00B0}", f)
+    }
+
     enum CodingKeys: String, CodingKey {
         case id, userId, imageURL, caption, timestamp, likes, isLiked
         case latitude, longitude, temp, weatherIcon, hashtags

--- a/PostCardView.swift
+++ b/PostCardView.swift
@@ -79,28 +79,30 @@ struct PostCardView: View {
     // MARK: – weather helper
     @ViewBuilder private var weatherIconView: some View {
         if let name = post.weatherSymbolName {
-            if let (primary, secondary) = post.weatherIconColors {
-                if let secondary = secondary {
-                    Image(systemName: name)
-                        .symbolRenderingMode(.palette)
-                        .foregroundStyle(primary, secondary)
-                        .padding(6)
-                        .background(.ultraThinMaterial, in: Circle())
-                        .padding(8)
+            HStack(spacing: 4) {
+                if let temp = post.tempString {
+                    Text(temp)
+                        .font(.caption)
+                        .fontWeight(.semibold)
+                }
+
+                if let (primary, secondary) = post.weatherIconColors {
+                    if let secondary = secondary {
+                        Image(systemName: name)
+                            .symbolRenderingMode(.palette)
+                            .foregroundStyle(primary, secondary)
+                    } else {
+                        Image(systemName: name)
+                            .symbolRenderingMode(.palette)
+                            .foregroundStyle(primary)
+                    }
                 } else {
                     Image(systemName: name)
-                        .symbolRenderingMode(.palette)
-                        .foregroundStyle(primary)
-                        .padding(6)
-                        .background(.ultraThinMaterial, in: Circle())
-                        .padding(8)
                 }
-            } else {
-                Image(systemName: name)
-                    .padding(6)
-                    .background(.ultraThinMaterial, in: Circle())
-                    .padding(8)
             }
+            .padding(6)
+            .background(.ultraThinMaterial, in: Capsule())
+            .padding(8)
         }
     }
 
@@ -134,8 +136,8 @@ struct PostCardView_Previews: PreviewProvider {
                 isLiked:   false,
                 latitude:  nil,
                 longitude: nil,
-                temp:      nil,
-                weatherIcon: nil,
+                temp:      22,
+                weatherIcon: "01d",
                 hashtags:  []
             )
         ) { }

--- a/PostDetailView.swift
+++ b/PostDetailView.swift
@@ -308,25 +308,29 @@ struct PostDetailView: View {
     // MARK: weather helper ------------------------------------
     @ViewBuilder private var weatherIconView: some View {
         if let name = post.weatherSymbolName {
-            if let (primary, secondary) = post.weatherIconColors {
-                if let secondary = secondary {
-                    Image(systemName: name)
-                        .symbolRenderingMode(.palette)
-                        .foregroundStyle(primary, secondary)
-                        .padding(6)
-                        .background(.ultraThinMaterial, in: Circle())
+            HStack(spacing: 4) {
+                if let temp = post.tempString {
+                    Text(temp)
+                        .font(.caption)
+                        .fontWeight(.semibold)
+                }
+
+                if let (primary, secondary) = post.weatherIconColors {
+                    if let secondary = secondary {
+                        Image(systemName: name)
+                            .symbolRenderingMode(.palette)
+                            .foregroundStyle(primary, secondary)
+                    } else {
+                        Image(systemName: name)
+                            .symbolRenderingMode(.palette)
+                            .foregroundStyle(primary)
+                    }
                 } else {
                     Image(systemName: name)
-                        .symbolRenderingMode(.palette)
-                        .foregroundStyle(primary)
-                        .padding(6)
-                        .background(.ultraThinMaterial, in: Circle())
                 }
-            } else {
-                Image(systemName: name)
-                    .padding(6)
-                    .background(.ultraThinMaterial, in: Circle())
             }
+            .padding(6)
+            .background(.ultraThinMaterial, in: Capsule())
         }
     }
 


### PR DESCRIPTION
## Summary
- add `tempString` helper on `Post` to format Fahrenheit temperature
- show temperature text next to weather icon in `PostCardView` overlay and post detail header
- tweak preview values to include weather example
- convert Celsius values to Fahrenheit when displaying temperature

## Testing
- `swift --version`


------
https://chatgpt.com/codex/tasks/task_e_685c73cac6a4832dae04eab76b3efbda