### PR TITLE
Improve post upload flow

### DIFF
--- a/HomeView.swift
+++ b/HomeView.swift
@@ -57,6 +57,9 @@ struct HomeView: View {
             }
             .refreshable { await refresh() }
             .onAppear(perform: initialLoad)
+            .onReceive(NotificationCenter.default.publisher(for: .didUploadPost)) { _ in
+                Task { await refresh() }
+            }
             .navigationBarHidden(true)
         }
     }

--- a/NewPostView.swift
+++ b/NewPostView.swift
@@ -92,7 +92,11 @@ struct NewPostView: View {
             }
             .background(
                 NavigationLink(isActive: $showCaption) {
-                    if let img = preview { PostCaptionView(image: img) }
+                    if let img = preview {
+                        PostCaptionView(image: img) {
+                            dismiss()
+                        }
+                    }
                 } label: { EmptyView() }.hidden()
             )
             .task(loadAssets)

--- a/PostCaptionView.swift
+++ b/PostCaptionView.swift
@@ -11,6 +11,7 @@ import CoreLocation
 struct PostCaptionView: View {
 
     let image: UIImage
+    var onComplete: (() -> Void)? = nil
 
     // caption & posting
     @State private var caption   = ""
@@ -197,6 +198,6 @@ struct PostCaptionView: View {
 
     private func dismissToRoot() {
         dismiss()
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) { dismiss() }
+        onComplete?()
     }
 }


### PR DESCRIPTION
## Summary
- support completion callback in PostCaptionView so the new-post sheet can be dismissed
- invoke completion when uploading a post
- pass dismiss closure from NewPostView to PostCaptionView
- refresh HomeView when a post uploads

## Testing
- `swift --version`
- `swift build` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_685cccadeb78832d9f4f65c08227684f