### PR TITLE
Enhance post creation UI with cropping

### DIFF
--- a/ImageCropperView.swift
+++ b/ImageCropperView.swift
@@ -1,0 +1,94 @@
+import SwiftUI
+
+struct ImageCropperView: View {
+    let image: UIImage
+    var onCropped: (UIImage) -> Void
+
+    @Environment(\.dismiss) private var dismiss
+
+    @State private var offset: CGSize = .zero
+    @State private var scale: CGFloat = 1
+    @GestureState private var dragOffset: CGSize = .zero
+    @GestureState private var pinchScale: CGFloat = 1
+
+    private let ratio: CGFloat = 1.25 // 4:5 aspect ratio
+
+    var body: some View {
+        NavigationStack {
+            GeometryReader { geo in
+                let frameWidth = geo.size.width
+                let frameHeight = frameWidth * ratio
+
+                ZStack {
+                    Color.black.ignoresSafeArea()
+
+                    Image(uiImage: image)
+                        .resizable()
+                        .scaledToFill()
+                        .frame(width: frameWidth, height: frameHeight)
+                        .offset(x: offset.width + dragOffset.width,
+                                y: offset.height + dragOffset.height)
+                        .scaleEffect(scale * pinchScale)
+                        .gesture(
+                            DragGesture()
+                                .updating($dragOffset) { value, state, _ in
+                                    state = value.translation
+                                }
+                                .onEnded { value in
+                                    offset.width += value.translation.width
+                                    offset.height += value.translation.height
+                                }
+                        )
+                        .gesture(
+                            MagnificationGesture()
+                                .updating($pinchScale) { value, state, _ in
+                                    state = value
+                                }
+                                .onEnded { value in
+                                    scale *= value
+                                }
+                        )
+                        .clipped()
+                        .overlay(
+                            Rectangle().stroke(Color.white, lineWidth: 2)
+                        )
+                }
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+                .toolbar {
+                    ToolbarItem(placement: .cancellationAction) {
+                        Button("Cancel") { dismiss() }
+                    }
+                    ToolbarItem(placement: .confirmationAction) {
+                        Button("Done") {
+                            if let cropped = crop(in: frameWidth, height: frameHeight) {
+                                onCropped(cropped)
+                            }
+                            dismiss()
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    private func crop(in width: CGFloat, height: CGFloat) -> UIImage? {
+        let displayScale = scale
+        let finalScale = displayScale * pinchScale
+        // Image display size after scaling
+        let dispW = width * finalScale
+        let dispH = height * finalScale
+
+        let x = (dispW - width)/2 - (offset.width + dragOffset.width)
+        let y = (dispH - height)/2 - (offset.height + dragOffset.height)
+
+        let xRatio = image.size.width / dispW
+        let yRatio = image.size.height / dispH
+
+        let cropRect = CGRect(x: x * xRatio,
+                              y: y * yRatio,
+                              width: width * xRatio,
+                              height: height * yRatio)
+        guard let cg = image.cgImage?.cropping(to: cropRect) else { return nil }
+        return UIImage(cgImage: cg)
+    }
+}

--- a/NewPostView.swift
+++ b/NewPostView.swift
@@ -22,6 +22,7 @@ struct NewPostView: View {
     // Selection
     @State private var selected : PHAsset?
     @State private var preview  : UIImage?
+    @State private var showCropper = false
     @State private var collapsed = false
     @State private var showCaption = false
 
@@ -43,6 +44,7 @@ struct NewPostView: View {
                         Image(uiImage: img)
                             .resizable()
                             .scaledToFill()
+                            .onTapGesture { showCropper = true }
                     } else {
                         Image(systemName: "photo")
                             .font(.system(size: 48))
@@ -65,7 +67,7 @@ struct NewPostView: View {
                     }
                     .frame(height: 0)
 
-                    LazyVGrid(columns: cols, spacing: 1) {
+                    LazyVGrid(columns: cols, spacing: 2) {
                         ForEach(assets, id: \.localIdentifier) { asset in
                             Thumb(asset: asset,
                                   manager: manager,
@@ -75,6 +77,7 @@ struct NewPostView: View {
                         }
                     }
                 }
+                .background(Color(.systemGray6))
                 .coordinateSpace(name: "scroll")
                 .onPreferenceChange(OffsetKey.self) { y in
                     withAnimation { collapsed = y < -40 }
@@ -99,6 +102,13 @@ struct NewPostView: View {
                     }
                 } label: { EmptyView() }.hidden()
             )
+            .sheet(isPresented: $showCropper) {
+                if let img = preview {
+                    ImageCropperView(image: img) { cropped in
+                        preview = cropped
+                    }
+                }
+            }
             .task(loadAssets)
         }
     }
@@ -163,8 +173,10 @@ fileprivate struct Thumb: View {
                     .padding(4)
             }
         }
+        .cornerRadius(4)
         .overlay(
-            Rectangle().stroke(Color(.systemGray4), lineWidth: 0.5)
+            RoundedRectangle(cornerRadius: 4)
+                .stroke(Color(.systemGray4).opacity(0.5), lineWidth: 0.5)
         )
         .onAppear(perform: loadThumb)
         .onTapGesture { onTap() }


### PR DESCRIPTION
## Summary
- make grid spacing lighter
- show a cropper when tapping the preview image
- smooth out thumbnail look with subtle corners
- add new `ImageCropperView` for pinch/drag cropping

## Testing
- `swift --version`

------
https://chatgpt.com/codex/tasks/task_e_685d410379b4832db644239e609f45c3