### PR TITLE
Improve Home feed layout

### DIFF
--- a/HomeView.swift
+++ b/HomeView.swift
@@ -40,7 +40,7 @@ struct HomeView: View {
                         column(for: leftColumn)
                         column(for: rightColumn)
                     }
-                    .padding(.horizontal, 16)
+                    .padding(.horizontal, 12)
 
                     if isLoadingPage {
                         ProgressView()
@@ -52,6 +52,7 @@ struct HomeView: View {
                             .font(.footnote)
                             .foregroundColor(.secondary)
                             .padding(.vertical, 32)
+                            .padding(.top, 16)
                     }
                 }
             }
@@ -77,7 +78,7 @@ struct HomeView: View {
             }
         }
         .padding(.horizontal, 16)
-        .padding(.top, 16)
+        .padding(.top, 24)
         .padding(.bottom, 8)
     }
 

--- a/PostCardView.swift
+++ b/PostCardView.swift
@@ -21,7 +21,9 @@ struct PostCardView: View {
 
             // ── Tap image → PostDetail ─────────────────────────────
             NavigationLink(destination: PostDetailView(post: post)) {
-                RemoteImage(url: post.imageURL, contentMode: .fit)
+                RemoteImage(url: post.imageURL, contentMode: .fill)
+                    .aspectRatio(4/5, contentMode: .fill)
+                    .clipped()
             }
             .buttonStyle(.plain)
 
@@ -34,8 +36,9 @@ struct PostCardView: View {
                         Text(isLoadingAuthor ? "Loading…" : authorName)
                             .font(.subheadline)
                             .fontWeight(.semibold)
-                            .lineLimit(1)
-                            .truncationMode(.tail)
+                            .lineLimit(2)
+                            .multilineTextAlignment(.center)
+                            .layoutPriority(1)
                     }
                 }
                 .buttonStyle(.plain)
@@ -43,10 +46,11 @@ struct PostCardView: View {
                 Spacer()
 
                 Button(action: onLike) {
-                    HStack(spacing: 4) {
+                    HStack(alignment: .center, spacing: 4) {
                         Image(systemName: post.isLiked ? "heart.fill" : "heart")
                         Text("\(post.likes)")
                     }
+                    .frame(width: 40)
                 }
                 .buttonStyle(.plain)
             }
@@ -55,8 +59,8 @@ struct PostCardView: View {
         }
         .background(Color.white)
         .cornerRadius(16)
-        .shadow(color: Color.black.opacity(0.05),
-                radius: 4, x: 0, y: 2)
+        .shadow(color: Color.black.opacity(0.1),
+                radius: 1, x: 0, y: 1)
         .overlay(alignment: .topTrailing) { weatherIconView }
         .onAppear(perform: fetchAuthor)
     }
@@ -101,7 +105,11 @@ struct PostCardView: View {
                 }
             }
             .padding(6)
-            .background(.ultraThinMaterial, in: Capsule())
+            .background(
+                .ultraThinMaterial,
+                in: RoundedRectangle(cornerRadius: 8, style: .continuous)
+            )
+            .shadow(color: Color.black.opacity(0.15), radius: 2, x: 0, y: 1)
             .padding(8)
         }
     }


### PR DESCRIPTION
## Summary
- pad feed masonry grid symmetrically
- crop feed photos to 4:5 aspect
- let user names wrap to two lines
- tweak like button layout
- restyle weather chip with rounded corners and shadow
- add breathing room above nav bar and footer
- apply subtle card shadow

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685e11ddf124832d9f4c97c445786be6