### PR TITLE
Fix Firestore ordering for hot posts

### DIFF
--- a/NetworkService+HotPosts.swift
+++ b/NetworkService+HotPosts.swift
@@ -25,8 +25,8 @@ extension NetworkService {
         let twelveHoursAgo = Date().addingTimeInterval(-12 * 60 * 60)
         var q: Query = db.collection("posts")
             .whereField("timestamp", isGreaterThan: Timestamp(date: twelveHoursAgo))
-            .order(by: "likes", descending: true)
             .order(by: "timestamp", descending: true)
+            .order(by: "likes", descending: true)
             .limit(to: 50)
         if let last { q = q.start(afterDocument: last) }
         q.getDocuments { [weak self] snap, err in
@@ -73,8 +73,15 @@ extension NetworkService {
             )
             hotPosts.append(post)
             seenUsers.insert(uid)
-            if hotPosts.count >= 10 { break }
         }
+        hotPosts.sort {
+            if $0.likes == $1.likes {
+                return $0.timestamp > $1.timestamp
+            } else {
+                return $0.likes > $1.likes
+            }
+        }
+        hotPosts = Array(hotPosts.prefix(10))
         completion(.success(.init(posts: hotPosts, lastDoc: snap.documents.last)))
     }
 }


### PR DESCRIPTION
## Summary
- update Firestore query in `NetworkService+HotPosts` to order by `timestamp` first
- sort hot post results by likes in memory before returning

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685eab7f0664832db04d77183cbc22c1