### PR TITLE
Improve hot posts ranking and animation

### DIFF
--- a/HomeView.swift
+++ b/HomeView.swift
@@ -116,17 +116,17 @@ struct HomeView: View {
                                 }
                             }
                             .padding(.horizontal, 6)
+                            .offset(x: hotRowOffset)
+                            .onAppear {
+                                withAnimation(
+                                    .easeInOut(duration: 8)
+                                        .repeatForever(autoreverses: true)
+                                ) {
+                                    hotRowOffset = 20
+                                }
+                            }
                         }
                         .frame(height: 72)
-                    }
-                    .offset(x: hotRowOffset)
-                    .onAppear {
-                        withAnimation(
-                            .easeInOut(duration: 8)
-                                .repeatForever(autoreverses: true)
-                        ) {
-                            hotRowOffset = 20
-                        }
                     }
                 }
                 .buttonStyle(.plain)
@@ -284,8 +284,8 @@ struct HomeView: View {
     // MARK: load hot posts
     private func loadHotPosts() async {
         do {
-            let bundle = try await NetworkService.shared.fetchHotPostsPage(startAfter: nil)
-            await MainActor.run { hotPosts = bundle.posts }
+            let bundle = try await NetworkService.shared.fetchHotPostsPage(startAfter: nil, limit: 100)
+            await MainActor.run { hotPosts = Array(bundle.posts.prefix(10)) }
         } catch {
             print("Hot posts error:", error.localizedDescription)
         }

--- a/HotPostsView.swift
+++ b/HotPostsView.swift
@@ -39,7 +39,7 @@ struct HotPostsView: View {
         isLoading = true
         defer { isLoading = false }
         do {
-            let bundle = try await NetworkService.shared.fetchHotPostsPage(startAfter: lastDoc)
+            let bundle = try await NetworkService.shared.fetchHotPostsPage(startAfter: lastDoc, limit: 100)
             lastDoc = bundle.lastDoc
             posts.append(contentsOf: bundle.posts)
         } catch {

--- a/NetworkService+HotPosts.swift
+++ b/NetworkService+HotPosts.swift
@@ -13,21 +13,23 @@ extension NetworkService {
     }
 
     // MARK: – async API
-    func fetchHotPostsPage(startAfter last: DocumentSnapshot?) async throws -> HotPostsBundle {
+    func fetchHotPostsPage(startAfter last: DocumentSnapshot?,
+                           limit: Int = 100) async throws -> HotPostsBundle {
         try await withCheckedThrowingContinuation { cont in
-            fetchHotPostsPage(startAfter: last) { cont.resume(with: $0) }
+            fetchHotPostsPage(startAfter: last, limit: limit) { cont.resume(with: $0) }
         }
     }
 
     // MARK: – closure API
     func fetchHotPostsPage(startAfter last: DocumentSnapshot?,
+                           limit: Int = 100,
                            completion: @escaping (Result<HotPostsBundle, Error>) -> Void) {
         let startOfToday = Calendar.current.startOfDay(for: Date())
         var q: Query = db.collection("posts")
             .whereField("timestamp", isGreaterThan: Timestamp(date: startOfToday))
             .order(by: "timestamp", descending: true)
             .order(by: "likes", descending: true)
-            .limit(to: 100)
+            .limit(to: limit)
         if let last { q = q.start(afterDocument: last) }
         q.getDocuments { [weak self] snap, err in
             self?.mapHotSnapshot(snapshot: snap, error: err, completion: completion)
@@ -45,7 +47,7 @@ extension NetworkService {
         }
         let me = Auth.auth().currentUser?.uid
         var seenUsers: Set<String> = []
-        var hotPosts: [Post] = []
+        var hotPosts: [(Post, Int)] = []
         for doc in snap.documents {
             let d = doc.data()
             guard
@@ -57,6 +59,8 @@ extension NetworkService {
             else { continue }
             if seenUsers.contains(uid) { continue }
             let likedBy = d["likedBy"] as? [String] ?? []
+            let commentCount = d["commentsCount"] as? Int ?? 0
+            let shareCount   = d["sharesCount"]   as? Int ?? 0
             let post = Post(
                 id:        doc.documentID,
                 userId:    uid,
@@ -71,17 +75,17 @@ extension NetworkService {
                 weatherIcon: d["weatherIcon"] as? String,
                 hashtags:  d["hashtags"]  as? [String] ?? []
             )
-            hotPosts.append(post)
+            let rating = (likes ?? 0) + commentCount + shareCount
+            hotPosts.append((post, rating))
             seenUsers.insert(uid)
         }
-        hotPosts.sort {
-            if $0.likes == $1.likes {
-                return $0.timestamp > $1.timestamp
+        hotPosts.sort { lhs, rhs in
+            if lhs.1 == rhs.1 {
+                return lhs.0.timestamp > rhs.0.timestamp
             } else {
-                return $0.likes > $1.likes
+                return lhs.1 > rhs.1
             }
         }
-        hotPosts = Array(hotPosts.prefix(10))
-        completion(.success(.init(posts: hotPosts, lastDoc: snap.documents.last)))
+        completion(.success(.init(posts: hotPosts.map(\.0), lastDoc: snap.documents.last)))
     }
 }


### PR DESCRIPTION
## Summary
- update HomeView hot post row so only images animate
- rank hot posts using likes and comments
- allow limiting hot posts fetch
- load only top 10 in home feed

## Testing
- `swiftc -parse HomeView.swift NetworkService+HotPosts.swift HotPostsView.swift >/tmp/parse.log && tail -n 20 /tmp/parse.log`

------
https://chatgpt.com/codex/tasks/task_e_686287fc90a8832da04bc61542f60cf7