### PR TITLE
Add rank numbers to hot posts

### DIFF
--- a/HomeView.swift
+++ b/HomeView.swift
@@ -118,13 +118,21 @@ struct HomeView: View {
                     // ── Avatars: each navigates to its own post
                     ScrollView(.horizontal, showsIndicators: false) {
                         HStack(spacing: 8) {
-                            ForEach(hotPosts) { post in
+                            ForEach(Array(hotPosts.enumerated()), id: \.element.id) { idx, post in
                                 NavigationLink {
                                     PostDetailView(post: post)
                                 } label: {
                                     RemoteImage(url: post.imageURL, contentMode: .fill)
                                         .frame(width: 64, height: 64)
                                         .clipShape(Circle())
+                                        .overlay(alignment: .bottomTrailing) {
+                                            Text("\(idx + 1)")
+                                                .font(.caption2.weight(.bold))
+                                                .padding(4)
+                                                .background(Color.black.opacity(0.6), in: Circle())
+                                                .foregroundColor(.white)
+                                                .padding(2)
+                                        }
                                 }
                                 .buttonStyle(.plain)
                             }


### PR DESCRIPTION
## Summary
- show ranking numbers over each Hot Today post avatar on the home feed

## Testing
- `swift --version`


------
https://chatgpt.com/codex/tasks/task_e_6863472dabb4832dae3fcdf74d0f5aa1