### PR TITLE
Improve Hot Posts screen

### DIFF
--- a/HotPostsView.swift
+++ b/HotPostsView.swift
@@ -17,18 +17,34 @@ struct HotPostsView: View {
     var body: some View {
         ScrollView {
             LazyVStack(spacing: 32) {
-                ForEach(posts) { post in
-                    PostDetailView(post: post)
+                ForEach(Array(posts.enumerated()), id: \.element.id) { idx, post in
+                    PostDetailView(post: post, navTitle: "🔥 Hot Today")
                         .background(Color(UIColor.systemBackground))
                         .clipShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
                         .shadow(color: .black.opacity(0.1), radius: 3, x: 0, y: 2)
                         .padding(.horizontal)
+                        .overlay(alignment: .bottomTrailing) {
+                            Text("\(idx + 1)")
+                                .font(.caption2.weight(.bold))
+                                .padding(6)
+                                .background(Color.black.opacity(0.6), in: Circle())
+                                .foregroundColor(.white)
+                                .padding(8)
+                        }
                         .onAppear { maybePrefetch(after: post) }
                 }
             }
             .padding(.vertical)
         }
         .navigationTitle("Hot Today")
+        .toolbar {
+            ToolbarItem(placement: .principal) {
+                HStack(spacing: 4) {
+                    Image(systemName: "flame.fill").foregroundColor(.red)
+                    Text("Hot Today")
+                }
+            }
+        }
         .task { await reload() }
         .refreshable { await reload() }
     }

--- a/PostDetailView.swift
+++ b/PostDetailView.swift
@@ -19,6 +19,7 @@ struct PostDetailView: View {
 
     // ── injected
     let post: Post
+    let navTitle: String
     @Environment(\.dismiss) private var dismiss
 
     // ── author
@@ -58,8 +59,9 @@ struct PostDetailView: View {
     @State private var imgRatio: CGFloat? = nil     // natural h/w
     @State private var faceTags: [UserTag] = []
 
-    init(post: Post) {
+    init(post: Post, navTitle: String = "Post") {
         self.post = post
+        self.navTitle = navTitle
         _isLiked     = State(initialValue: post.isLiked)
         _likesCount  = State(initialValue: post.likes)
         _outfitItems = State(initialValue: post.outfitItems ?? [])
@@ -94,7 +96,7 @@ struct PostDetailView: View {
             }
         }
         .animation(.easeInOut, value: showComments)
-        .navigationTitle("Post")
+        .navigationTitle(navTitle)
         .navigationBarTitleDisplayMode(.inline)
         .alert("Delete Post?", isPresented: $showDeleteConfirm,
                actions: deleteAlertButtons)


### PR DESCRIPTION
## Summary
- customize `PostDetailView` to accept a navigation title
- display the flame icon in Hot Posts header
- show ranking badges on each post in Hot Posts list

## Testing
- `swift --version`
- `swift build` *(fails: Could not find Package.swift)*
- `swiftlint` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6863f5ef46cc832db7b160390088205c