### PR TITLE
Change icons and accents to black

### DIFF
--- a/ChatDetailView.swift
+++ b/ChatDetailView.swift
@@ -76,7 +76,7 @@ struct ChatDetailView: View {
                 .padding(10)
                 .background(incoming
                             ? Color.gray.opacity(0.2)
-                            : Color.blue.opacity(0.8))
+                            : Color.black.opacity(0.8))
                 .foregroundColor(incoming ? .primary : .white)
                 .cornerRadius(12)
                 .frame(maxWidth: 250, alignment: incoming ? .leading : .trailing)

--- a/ExploreView.swift
+++ b/ExploreView.swift
@@ -147,7 +147,7 @@ struct ExploreView: View {
                         .padding(.vertical, 6)
                         .padding(.horizontal, 12)
                         .background(selectedChip == chip
-                                    ? Color.blue
+                                    ? Color.black
                                     : Color(.systemGray5))
                         .foregroundColor(selectedChip == chip
                                          ? .white : .primary)

--- a/FitSpoApp.swift
+++ b/FitSpoApp.swift
@@ -9,6 +9,7 @@ struct FitSpoApp: App {
     var body: some Scene {
         WindowGroup {
             ContentView()
+                .accentColor(.black)
         }
     }
 }

--- a/NewPostView.swift
+++ b/NewPostView.swift
@@ -225,7 +225,7 @@ fileprivate struct Thumb: View {
 
             if selected {
                 Image(systemName: "checkmark.circle.fill")
-                    .foregroundColor(.blue)
+                    .foregroundColor(.black)
                     .padding(4)
             }
         }

--- a/ProfileView.swift
+++ b/ProfileView.swift
@@ -195,7 +195,7 @@ struct ProfileView: View {
     @ViewBuilder
     private func navStat<Dest: View>(count: Int, label: String, destination: Dest) -> some View {
         NavigationLink(destination: destination) {
-            statView(count: count, label: label).foregroundColor(.blue)
+            statView(count: count, label: label).foregroundColor(.black)
         }
         .buttonStyle(PlainButtonStyle())
     }

--- a/SignInView.swift
+++ b/SignInView.swift
@@ -41,7 +41,7 @@ struct SignInView: View {
             }
             .disabled(isLoading || email.isEmpty || password.isEmpty)
             .padding()
-            .background(Color.blue)
+            .background(Color.black)
             .foregroundColor(.white)
             .cornerRadius(8)
 

--- a/TagPlacementOverlay.swift
+++ b/TagPlacementOverlay.swift
@@ -35,7 +35,7 @@ struct TagPlacementOverlay: View {
                     // movable pin
                     if let p = currentPos {
                         Circle()
-                            .fill(Color.accentColor)
+                            .fill(Color.black)
                             .frame(width: 20, height: 20)
                             .position(p)
                             .gesture(


### PR DESCRIPTION
## Summary
- make accent color black globally
- update follow stat links, new post selector checkmarks, and explore chips to black
- update Sign In button to black
- update outgoing message bubbles to black
- update overlay pin color to black

## Testing
- `swiftc --version`

------
https://chatgpt.com/codex/tasks/task_e_686462144908832da54ac0fa13c58968