### PR TITLE
Enable like notifications

### DIFF
--- a/ActivityView.swift
+++ b/ActivityView.swift
@@ -37,6 +37,7 @@ private struct NotificationRow: View {
         switch note.kind {
         case .mention: return "mentioned you"
         case .comment: return "commented on your post"
+        case .like:    return "liked your post"
         }
     }
 
@@ -51,9 +52,11 @@ private struct NotificationRow: View {
             VStack(alignment: .leading, spacing: 4) {
                 Text("\(note.fromUsername) \(message)")
                     .font(.subheadline)
-                Text(note.text)
-                    .font(.caption)
-                    .foregroundColor(.secondary)
+                if note.kind != .like {
+                    Text(note.text)
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                }
             }
             Spacer(minLength: 0)
         }

--- a/NetworkService+Notifications.swift
+++ b/NetworkService+Notifications.swift
@@ -94,4 +94,27 @@ extension NetworkService {
             }
         }
     }
+
+    // MARK: - Convenience: create notification for a like
+    func handleLikeNotification(postOwnerId: String,
+                                postId: String,
+                                fromUserId: String) {
+        guard postOwnerId != fromUserId else { return }
+
+        db.collection("users").document(fromUserId).getDocument { snap, _ in
+            let data = snap?.data() ?? [:]
+            let name   = data["displayName"] as? String ??
+                         Auth.auth().currentUser?.displayName ?? "User"
+            let avatar = data["avatarURL"] as? String ??
+                         Auth.auth().currentUser?.photoURL?.absoluteString
+
+            let note = UserNotification(postId: postId,
+                                       fromUserId: fromUserId,
+                                       fromUsername: name,
+                                       fromAvatarURL: avatar,
+                                       text: "",
+                                       kind: .like)
+            self.addNotification(to: postOwnerId, notification: note) { _ in }
+        }
+    }
 }

--- a/NetworkService.swift
+++ b/NetworkService.swift
@@ -265,6 +265,11 @@ final class NetworkService {
             var updated = post
             updated.likes   = newLikes
             updated.isLiked = shouldLike
+            if shouldLike {
+                self.handleLikeNotification(postOwnerId: post.userId,
+                                           postId: post.id,
+                                           fromUserId: uid)
+            }
             completion(.success(updated))
         }
     }

--- a/README.md
+++ b/README.md
@@ -13,4 +13,4 @@ likes.
 
 ## Activity
 
-A simple Activity screen lists your notifications. Access it from the bell icon in the top-left corner of the Home view.
+A simple Activity screen lists your notifications. Access it from the bell icon in the top-left corner of the Home view. You will be notified when someone comments on or likes your posts.

--- a/UserNotification.swift
+++ b/UserNotification.swift
@@ -2,7 +2,7 @@ import Foundation
 
 /// A single in-app notification for the Activity screen.
 struct UserNotification: Identifiable, Codable {
-    enum Kind: String, Codable { case mention, comment }
+    enum Kind: String, Codable { case mention, comment, like }
 
     let id: String
     let postId: String


### PR DESCRIPTION
## Summary
- include `like` in the `UserNotification.Kind` enum
- show a message when someone likes your post
- create like notifications when toggling likes
- document this in README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6864a5beffa4832d90100a92de9a7f92