### PR TITLE
Add notifications for user tags

### DIFF
--- a/ActivityView.swift
+++ b/ActivityView.swift
@@ -38,6 +38,7 @@ private struct NotificationRow: View {
         case .mention: return "mentioned you"
         case .comment: return "commented on your post"
         case .like:    return "liked your post"
+        case .tag:     return "tagged you in a post"
         }
     }
 

--- a/NetworkService.swift
+++ b/NetworkService.swift
@@ -164,8 +164,15 @@ final class NetworkService {
                         }
                         batch.commit { err in
                             NotificationCenter.default.post(name: .didUploadPost, object: nil)
-                            err == nil ? completion(.success(()))
-                                       : completion(.failure(err!))
+                            if err == nil {
+                                self.handleTagNotifications(postId: doc.documentID,
+                                                           caption: caption,
+                                                           fromUserId: me.uid,
+                                                           taggedUsers: tags)
+                                completion(.success(()))
+                            } else {
+                                completion(.failure(err!))
+                            }
                         }
                     }
                 }

--- a/UserNotification.swift
+++ b/UserNotification.swift
@@ -2,7 +2,7 @@ import Foundation
 
 /// A single in-app notification for the Activity screen.
 struct UserNotification: Identifiable, Codable {
-    enum Kind: String, Codable { case mention, comment, like }
+    enum Kind: String, Codable { case mention, comment, like, tag }
 
     let id: String
     let postId: String


### PR DESCRIPTION
## Summary
- support a new notification type when a user is tagged in a post
- display tag notifications on the Activity screen
- send tag notifications after uploading a post

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6864aa9f3b94832d9ecb4be2f331e075