### PR TITLE
Remove notifications linked to deleted posts

### DIFF
--- a/NetworkService+Notifications.swift
+++ b/NetworkService+Notifications.swift
@@ -144,4 +144,18 @@ extension NetworkService {
             }
         }
     }
+
+    // MARK: - Remove notifications for a deleted post
+    /// Delete any notifications that reference the given post ID.
+    func deleteNotifications(forPostId postId: String,
+                             completion: ((Error?) -> Void)? = nil) {
+        db.collectionGroup("notifications")
+            .whereField("postId", isEqualTo: postId)
+            .getDocuments { snap, err in
+                if let err = err { completion?(err); return }
+                let batch = self.db.batch()
+                snap?.documents.forEach { batch.deleteDocument($0.reference) }
+                batch.commit { batchErr in completion?(batchErr) }
+            }
+    }
 }

--- a/NetworkService.swift
+++ b/NetworkService.swift
@@ -294,8 +294,9 @@ final class NetworkService {
                     .delete { _ in }
             }
             ref.delete { err in
-                err == nil ? completion(.success(()))
-                           : completion(.failure(err!))
+                if let err { completion(.failure(err)); return }
+                self.deleteNotifications(forPostId: id) { _ in }
+                completion(.success(()))
             }
         }
     }


### PR DESCRIPTION
## Summary
- add a helper to delete notifications associated with a post
- call that helper when a post is removed

## Testing
- `swiftlint` *(fails: command not found)*
- `swift test` *(fails: no Package.swift found)*

------
https://chatgpt.com/codex/tasks/task_e_68652c5f1d28832d9f639549adc8ebf0