### PR TITLE
Fix stale activity notifications

### DIFF
--- a/ActivityView.swift
+++ b/ActivityView.swift
@@ -97,9 +97,13 @@ private struct NotificationRow: View {
         guard !isLoadingPost else { return }
         isLoadingPost = true
         NetworkService.shared.fetchPost(id: note.postId) { result in
-            if case .success(let p) = result {
-                DispatchQueue.main.async {
-                    post = p
+            switch result {
+            case .success(let p):
+                DispatchQueue.main.async { post = p }
+            case .failure:
+                if let uid = Auth.auth().currentUser?.uid {
+                    NetworkService.shared.deleteNotification(userId: uid,
+                                                           notificationId: note.id) { _ in }
                 }
             }
             isLoadingPost = false

--- a/NetworkService+Notifications.swift
+++ b/NetworkService+Notifications.swift
@@ -158,4 +158,16 @@ extension NetworkService {
                 batch.commit { batchErr in completion?(batchErr) }
             }
     }
+
+    // MARK: - Remove a single notification
+    /// Delete the specified notification for the given user.
+    func deleteNotification(userId: String,
+                            notificationId: String,
+                            completion: ((Error?) -> Void)? = nil) {
+        db.collection("users")
+            .document(userId)
+            .collection("notifications")
+            .document(notificationId)
+            .delete { err in completion?(err) }
+    }
 }


### PR DESCRIPTION
## Summary
- remove stale notifications referencing deleted posts
- clean up activity page when posts are gone

## Testing
- `swift build` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68656073ee08832d92d3b76fb166aadf