### PR TITLE
Enable post search via Algolia

### DIFF
--- a/Post.swift
+++ b/Post.swift
@@ -31,6 +31,9 @@ struct Post: Identifiable, Codable {
     // hashtags
     var hashtags: [String]
 
+    /// Optional Algolia object identifier
+    var objectID: String? = nil
+
     // convenience
     var coordinate: CLLocationCoordinate2D? {
         guard let lat = latitude, let lon = longitude else { return nil }
@@ -82,6 +85,6 @@ struct Post: Identifiable, Codable {
     enum CodingKeys: String, CodingKey {
         case id, userId, imageURL, caption, timestamp, likes, isLiked
         case latitude, longitude, temp, weatherIcon, hashtags
-        case outfitItems, outfitTags
+        case outfitItems, outfitTags, objectID
     }
 }

--- a/SearchResultsView.swift
+++ b/SearchResultsView.swift
@@ -4,30 +4,59 @@
 //
 
 import SwiftUI
+import AlgoliaSearchClient
 
 /// Stand-alone screen shown when user taps a username / hashtag result.
 struct SearchResultsView: View {
     let query: String                 // either "@sofia" or "#beach"
     @State private var users: [UserLite] = []
+    @State private var posts: [Post] = []
     @State private var isLoading = false
     @Environment(\.dismiss) private var dismiss
 
+    // Masonry split columns like HomeView
+    private var leftColumn: [Post] {
+        posts.enumerated().filter { $0.offset.isMultiple(of: 2) }.map(\.element)
+    }
+    private var rightColumn: [Post] {
+        posts.enumerated().filter { !$0.offset.isMultiple(of: 2) }.map(\.element)
+    }
+
     var body: some View {
         NavigationStack {
-            List {
+            Group {
                 if query.first == "#" {
-                    // TODO: hashtag deep-dive (Phase 2.3)
-                    Text("Hashtag search coming next…")
-                        .foregroundColor(.secondary)
+                    List {
+                        // TODO: hashtag deep-dive (Phase 2.3)
+                        Text("Hashtag search coming next…")
+                            .foregroundColor(.secondary)
+                    }
+                } else if query.first == "@" {
+                    List {
+                        ForEach(users) { u in
+                            NavigationLink(destination: ProfileView(userId: u.id)) {
+                                AccountRow(user: u)
+                            }
+                        }
+                    }
                 } else {
-                    ForEach(users) { u in
-                        NavigationLink(destination: ProfileView(userId: u.id)) {
-                            AccountRow(user: u)
+                    ScrollView {
+                        if isLoading {
+                            ProgressView().padding(.top, 40)
+                        } else if posts.isEmpty {
+                            Text("No results found")
+                                .foregroundColor(.secondary)
+                                .padding(.top, 40)
+                        } else {
+                            HStack(alignment: .top, spacing: 8) {
+                                column(for: leftColumn)
+                                column(for: rightColumn)
+                            }
+                            .padding(.horizontal, 12)
                         }
                     }
                 }
             }
-            .overlay { if isLoading { ProgressView() } }
             .navigationTitle(query)
             .toolbar { ToolbarItem(placement: .navigationBarTrailing) {
                 Button("Close") { dismiss() }
@@ -38,10 +67,47 @@ struct SearchResultsView: View {
 
     @MainActor
     private func runSearch() async {
-        guard query.first != "#" else { return }
         isLoading = true
-        do { users = try await NetworkService.shared.searchUsers(prefix: query) }
-        catch { print("User search error:", error.localizedDescription) }
-        isLoading = false
+        defer { isLoading = false }
+
+        if query.first == "@" {
+            do {
+                users = try await NetworkService.shared.searchUsers(prefix: query)
+            } catch {
+                print("User search error:", error.localizedDescription)
+            }
+        } else if query.first == "#" {
+            // Placeholder for hashtag search
+        } else {
+            await searchPosts()
+        }
+    }
+
+    // MARK: - Algolia helper
+    @MainActor
+    private func searchPosts() async {
+        do {
+            let client = SearchClient(appID: "<APP_ID>", apiKey: "<SEARCH_ONLY_KEY>")
+            let index  = client.index(withName: "posts")
+            let response = try await index.search(query: Query(query).set(\.hitsPerPage, to: 40))
+            let hits: [Hit<Post>] = try response.decodeHits()
+            posts = hits.map { hit in
+                var p = hit.object
+                p.objectID = hit.objectID
+                return p
+            }
+        } catch {
+            print("Algolia search error:", error.localizedDescription)
+            posts = []
+        }
+    }
+
+    @ViewBuilder
+    private func column(for list: [Post]) -> some View {
+        LazyVStack(spacing: 8) {
+            ForEach(list) { post in
+                PostCardView(post: post, onLike: {})
+            }
+        }
     }
 }


### PR DESCRIPTION
## Summary
- add `objectID` to `Post` for Algolia decoding
- query Algolia from `SearchResultsView` when query is plain text
- show returned posts in the existing PostCard grid

## Testing
- `swift --version`

------
https://chatgpt.com/codex/tasks/task_e_6875c087edec832d9f8a025d74abf9be