### PR TITLE
Enable post search with Algolia

### DIFF
--- a/ExploreView.swift
+++ b/ExploreView.swift
@@ -27,6 +27,7 @@ struct ExploreView: View {
     @State private var searchText = ""
     @State private var accountHits: [UserLite] = []
     @State private var isSearchingAccounts = false
+    @State private var showResults = false
 
     // chips / filters
     @State private var selectedChip = "All"
@@ -62,11 +63,15 @@ struct ExploreView: View {
             }
             .searchable(text: $searchText,
                         prompt: "Search accounts or #tags")
+            .onSubmit(of: .search) { if !searchText.isEmpty { showResults = true } }
             .onChange(of: searchText,  perform: handleSearchChange)
             .onChange(of: selectedChip) { _ in applyFilter() }
             .onChange(of: filter)       { _ in applyFilter() }
             .refreshable { await reload(clear: true) }
             .task        { await coldStart() }
+            .navigationDestination(isPresented: $showResults) {
+                SearchResultsView(query: searchText)
+            }
         }
     }
 
@@ -172,7 +177,10 @@ struct ExploreView: View {
                                 .padding(.horizontal, 12)
                                 .background(Color(.systemGray5))
                                 .clipShape(Capsule())
-                                .onTapGesture { searchText = "#"+tag }
+                                .onTapGesture {
+                                    searchText = "#" + tag
+                                    showResults = true
+                                }
                         }
                     }
                     .padding(.horizontal, 6)

--- a/Post.swift
+++ b/Post.swift
@@ -14,6 +14,7 @@ struct Post: Identifiable, Codable {
     let userId:    String
     let imageURL:  String
     let caption:   String
+    var username:  String? = nil
     let timestamp: Date
     var likes:     Int
     var isLiked:   Bool
@@ -83,7 +84,7 @@ struct Post: Identifiable, Codable {
 
 
     enum CodingKeys: String, CodingKey {
-        case id, userId, imageURL, caption, timestamp, likes, isLiked
+        case id, userId, imageURL, caption, username, timestamp, likes, isLiked
         case latitude, longitude, temp, weatherIcon, hashtags
         case outfitItems, outfitTags, objectID
     }

--- a/SearchResultsView.swift
+++ b/SearchResultsView.swift
@@ -76,8 +76,6 @@ struct SearchResultsView: View {
             } catch {
                 print("User search error:", error.localizedDescription)
             }
-        } else if query.first == "#" {
-            // Placeholder for hashtag search
         } else {
             await searchPosts()
         }
@@ -93,11 +91,16 @@ struct SearchResultsView: View {
                 query: Query(query).set(\.hitsPerPage, to: 40)
             )
 
+            let decoder = JSONDecoder()
+            decoder.dateDecodingStrategy = .millisecondsSince1970
+
             posts = try response.hits.map { hit in
-                // decode the JSON hit payload into Post
-                let data = try JSONSerialization.data(withJSONObject: hit)
-                var post = try JSONDecoder().decode(Post.self, from: data)
-                // hit.objectID is a struct; take its rawValue String
+                var payload = hit
+                if payload["id"] == nil {
+                    payload["id"] = hit.objectID.rawValue
+                }
+                let data = try JSONSerialization.data(withJSONObject: payload)
+                var post = try decoder.decode(Post.self, from: data)
                 post.objectID = hit.objectID.rawValue
                 return post
             }

--- a/functions/index.ts
+++ b/functions/index.ts
@@ -1,0 +1,42 @@
+import * as functions from 'firebase-functions';
+import * as admin from 'firebase-admin';
+import algoliasearch from 'algoliasearch';
+
+admin.initializeApp();
+
+const ALGOLIA_APP_ID = '6WFE31B7U3';
+const ALGOLIA_ADMIN_KEY = functions.config().algolia.key;
+const client = algoliasearch(ALGOLIA_APP_ID, ALGOLIA_ADMIN_KEY);
+const index = client.initIndex('posts');
+
+const settingsPromise = index.setSettings({
+  searchableAttributes: ['caption', 'hashtags', 'username'],
+  customRanking: ['desc(timestamp)', 'desc(likes)'],
+});
+
+export const syncPostToAlgolia = functions.firestore
+  .document('posts/{postId}')
+  .onWrite(async (change, context) => {
+    await settingsPromise;
+
+    if (!change.after.exists) {
+      await index.deleteObject(context.params.postId);
+      return;
+    }
+
+    const data = change.after.data() || {};
+    const postId = context.params.postId;
+
+    const record = {
+      objectID: postId,
+      id: postId,
+      caption: data.caption || '',
+      hashtags: (data.hashtags || []).map((h: string) => h.toLowerCase()),
+      username: data.username || '',
+      imageURL: data.imageURL || '',
+      timestamp: data.timestamp ? data.timestamp.toMillis() : Date.now(),
+      likes: data.likes || 0,
+    };
+
+    await index.saveObject(record);
+  });


### PR DESCRIPTION
## Summary
- add Firebase function to sync posts to Algolia
- include optional `username` in `Post`
- improve Algolia decoding in `SearchResultsView`
- push search results from Explore view

## Testing
- `swift --version`
- `npx tsc functions/index.ts --outDir functions/dist` *(fails: Cannot find module 'firebase-functions')*

------
https://chatgpt.com/codex/tasks/task_e_68765d4205e0832d953bc4016dd9b453